### PR TITLE
RESTful Service 기능 확장 - validation 및 internationalized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/restfulwebservice/RestfulWebServiceApplication.java
+++ b/src/main/java/com/example/restfulwebservice/RestfulWebServiceApplication.java
@@ -2,6 +2,11 @@ package com.example.restfulwebservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+
+import static java.util.Locale.KOREA;
 
 @SpringBootApplication
 public class RestfulWebServiceApplication {
@@ -9,5 +14,12 @@ public class RestfulWebServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(RestfulWebServiceApplication.class, args);
 	}
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        SessionLocaleResolver localeResolver = new SessionLocaleResolver();
+        localeResolver.setDefaultLocale(KOREA);
+        return localeResolver;
+    }
 
 }

--- a/src/main/java/com/example/restfulwebservice/exception/CustomResponseEntityExceptionHandler.java
+++ b/src/main/java/com/example/restfulwebservice/exception/CustomResponseEntityExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.example.restfulwebservice.exception;
 
 import com.example.restfulwebservice.user.UserNotFoundException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,8 +13,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import java.util.Date;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @ControllerAdvice // 모든 컨트롤러에서 발생할 수 있는 예외를 잡아 처리해주는 어노테이션
@@ -31,6 +33,17 @@ public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptio
                 new ExceptionResponse(new Date(), ex.getMessage(), request.getDescription(false));
 
         return new ResponseEntity<>(exceptionResponse, NOT_FOUND);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        ExceptionResponse exceptionResponse
+                = new ExceptionResponse(new Date(), "Validation Failed", ex.getBindingResult().toString());
+
+        return new ResponseEntity<>(exceptionResponse, BAD_REQUEST);
     }
 
 }

--- a/src/main/java/com/example/restfulwebservice/helloworld/HelloWorldController.java
+++ b/src/main/java/com/example/restfulwebservice/helloworld/HelloWorldController.java
@@ -1,11 +1,19 @@
 package com.example.restfulwebservice.helloworld;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Locale;
+
 @RestController
+@RequiredArgsConstructor
 public class HelloWorldController {
+
+    private final MessageSource messageSource;
 
     @GetMapping("/hello-world")
     public String helloWorld() {
@@ -23,6 +31,12 @@ public class HelloWorldController {
     @GetMapping("/hello-world-bean/path-variable/{name}")
     public HelloWorldBean helloWorldPathVariable(@PathVariable String name) {
         return new HelloWorldBean(String.format("Hello World, %s", name));
+    }
+
+    @GetMapping("/hello-world-internationalized")
+    public String helloWorldInternationalized(
+            @RequestHeader(name = "Accept-Language", required = false) Locale locale) {
+        return messageSource.getMessage("greeting.message", null, locale);
     }
 
 }

--- a/src/main/java/com/example/restfulwebservice/user/User.java
+++ b/src/main/java/com/example/restfulwebservice/user/User.java
@@ -3,6 +3,8 @@ package com.example.restfulwebservice.user;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import javax.validation.constraints.Past;
+import javax.validation.constraints.Size;
 import java.util.Date;
 
 @Data
@@ -10,7 +12,11 @@ import java.util.Date;
 public class User {
 
     private Integer id;
+
+    @Size(min = 2, message = "Name은 2글자 이상 입력해주세요.")
     private String name;
+
+    @Past
     private Date joinDate;
 
 }

--- a/src/main/java/com/example/restfulwebservice/user/UserController.java
+++ b/src/main/java/com/example/restfulwebservice/user/UserController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class UserController {
     }
 
     @PostMapping("/users")
-    public ResponseEntity<User> createUser(@RequestBody User user) {
+    public ResponseEntity<User> createUser(@Valid @RequestBody User user) {
         User savedUser = service.save(user);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@ spring:
   output:
     ansi:
       enabled: always
+  message:
+    basename: messages
 
 server:
   port: 8088

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+greeting.message=안녕하세요

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,1 @@
+greeting.message=Hello

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -1,0 +1,1 @@
+greeting.message=Bonjour


### PR DESCRIPTION
## validation
  - 컨트롤러에서 검증할 객체에 대하여 `@Valid`를 붙혀서 사용자 입력 값에 대한 유효성 체크를 하도록 함
  - `handleMethodArgumentNotValid`를 오버라이딩해서 검증 예외 발생 시 내용을 전달하도록 함


## internationalized
- `localeResolver`를 스프링 빈으로 등록
- `yml`에 사용 할 메세지 파일의 이름 등록
   - `message.properties`
   - `message_en.properties`
   - `messgate_fr.properties`
- HTTP 요청 헤더의 `Accept-Language` 값을 통해 `locale` 값을 받아와 다국어 처리