### PR TITLE
RESTful Service 기능 확장 - Response 데이터 제어

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/restfulwebservice/user/AdminUserController.java
+++ b/src/main/java/com/example/restfulwebservice/user/AdminUserController.java
@@ -1,6 +1,9 @@
 package com.example.restfulwebservice.user;
 
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.converter.json.MappingJacksonValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,19 +19,37 @@ public class AdminUserController {
     private final UserDaoService service;
 
     @GetMapping("/users")
-    public List<User> retrieveAllUsers() {
-        return service.findAll();
+    public MappingJacksonValue retrieveAllUsers() {
+        List<User> users = service.findAll();
+
+        SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter
+                .filterOutAllExcept("id", "name", "joinDate", "password");
+
+        SimpleFilterProvider filters = new SimpleFilterProvider().addFilter("UserInfo", filter); // 필터 생성
+
+        MappingJacksonValue mapping = new MappingJacksonValue(users); // 데이터 변환
+        mapping.setFilters(filters); // 필터링 적용
+
+        return mapping;
     }
 
     @GetMapping("/users/{id}")
-    public User retrieveUser(@PathVariable int id) {
+    public MappingJacksonValue retrieveUser(@PathVariable int id) {
         User user = service.findOne(id);
 
         if (user == null) {
             throw new UserNotFoundException(String.format("ID[%S] not found", id));
         }
 
-        return user;
+        SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter
+                .filterOutAllExcept("id", "name", "joinDate", "ssn");
+
+        SimpleFilterProvider filters = new SimpleFilterProvider().addFilter("UserInfo", filter); // 필터 생성
+
+        MappingJacksonValue mapping = new MappingJacksonValue(user); // 데이터 변환
+        mapping.setFilters(filters); // 필터링 적용
+
+        return mapping;
     }
 
 }

--- a/src/main/java/com/example/restfulwebservice/user/AdminUserController.java
+++ b/src/main/java/com/example/restfulwebservice/user/AdminUserController.java
@@ -1,0 +1,34 @@
+package com.example.restfulwebservice.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminUserController {
+
+    private final UserDaoService service;
+
+    @GetMapping("/users")
+    public List<User> retrieveAllUsers() {
+        return service.findAll();
+    }
+
+    @GetMapping("/users/{id}")
+    public User retrieveUser(@PathVariable int id) {
+        User user = service.findOne(id);
+
+        if (user == null) {
+            throw new UserNotFoundException(String.format("ID[%S] not found", id));
+        }
+
+        return user;
+    }
+
+}

--- a/src/main/java/com/example/restfulwebservice/user/User.java
+++ b/src/main/java/com/example/restfulwebservice/user/User.java
@@ -1,6 +1,6 @@
 package com.example.restfulwebservice.user;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -10,7 +10,7 @@ import java.util.Date;
 
 @Data
 @AllArgsConstructor
-@JsonIgnoreProperties(value = {"password", "ssn"})
+@JsonFilter("UserInfo")
 public class User {
 
     private Integer id;

--- a/src/main/java/com/example/restfulwebservice/user/User.java
+++ b/src/main/java/com/example/restfulwebservice/user/User.java
@@ -1,5 +1,6 @@
 package com.example.restfulwebservice.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -18,5 +19,11 @@ public class User {
 
     @Past
     private Date joinDate;
+
+    @JsonIgnore
+    private String password;
+
+    @JsonIgnore
+    private String ssn;
 
 }

--- a/src/main/java/com/example/restfulwebservice/user/User.java
+++ b/src/main/java/com/example/restfulwebservice/user/User.java
@@ -1,6 +1,6 @@
 package com.example.restfulwebservice.user;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -10,6 +10,7 @@ import java.util.Date;
 
 @Data
 @AllArgsConstructor
+@JsonIgnoreProperties(value = {"password", "ssn"})
 public class User {
 
     private Integer id;
@@ -20,10 +21,8 @@ public class User {
     @Past
     private Date joinDate;
 
-    @JsonIgnore
     private String password;
 
-    @JsonIgnore
     private String ssn;
 
 }

--- a/src/main/java/com/example/restfulwebservice/user/UserDaoService.java
+++ b/src/main/java/com/example/restfulwebservice/user/UserDaoService.java
@@ -14,9 +14,9 @@ public class UserDaoService {
     private static int usersCount = 3;
 
     static {
-        users.add(new User(1, "Anne", new Date()));
-        users.add(new User(2, "Jolly", new Date()));
-        users.add(new User(3, "Alice", new Date()));
+        users.add(new User(1, "Anne", new Date(), "pass1", "701010-111111"));
+        users.add(new User(2, "Jolly", new Date(), "pass2", "801010-222222"));
+        users.add(new User(3, "Alice", new Date(), "pass3", "901010-222222"));
     }
 
     public List<User> findAll() {


### PR DESCRIPTION
## Response 데이터 형식 제어
- 응답 데이터 형식을 스프링이 기본적으로 제공하는 `JSON`이 아닌 `XML`형식으로 변환해서 반환하기 위한 의존성 추가
```
<dependency>
	<groupId>com.fasterxml.jackson.dataformat</groupId>
	<artifactId>jackson-dataformat-xml</artifactId>
</dependency>
```
- 포스트맨으로 확인하는 방법 : `Headers`의 `Accept`를 `application/xml`로 지정

<br>

## Response 데이터 내용 제어
- 객체 멤버변수에 직접 `@JsonIgnore`를 이용해 제어
- 클래스 단위에 `@JsonIgnoreProperties`를 이용해 제어
- `@JasonFilter`를 이용해 프로그래밍으로 제어 
  - `SimpleBeanPropertyFilter`를 통해 필터링 할 내용을 지정 
  - 필터링된 데이터값을 반환하기 위해서는 `MappingJacksonValue` 객체로 변환해 반환해야 함