### PR TITLE
Hal Explorer 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-rest-hal-explorer</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
- Hal Explorer 의존성 추가
```xml
<dependency>
	<groupId>org.springframework.data</groupId>
	<artifactId>spring-data-rest-hal-explorer</artifactId>
</dependency>
```

- Hal Explorer 확인하기 : `localhost:8088/`

![image](https://user-images.githubusercontent.com/91456818/191030318-23ef7372-8537-415a-90ca-627e0224a305.png)
